### PR TITLE
content version for S3 Objects

### DIFF
--- a/journal/week1.md
+++ b/journal/week1.md
@@ -72,3 +72,13 @@ In terraform there is a special variable called `path` that allows us to referen
 ### AWS S3 Bucket Policy
 - Attach a policy to an S3 bucket to allow CloudFront to access objects in the bucket.
 - [Terraform Registry S3 Bucket Policy Documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy). 
+
+## Content Version and Terraform Data 
+
+### Terraform Resource LifeCycle
+- Lifecycle management was used to ignore changes to to S3 objects(index.html and error.html) resource attributes. 
+- [Terraform Resource Lifecycle Documentation](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle).
+
+### Terraform Data Resource
+- The terraform_data resource is useful for storing values which need to follow a manage resource lifecycle, for this project--the terraform_data resource triggers the S3 objects(index.html and error.html) to be updated only when the `var.content_version` is incremented, but this does invalidate the cache which i will cover in another step in this journal.
+- [Terraform Data Resource Documentation](https://developer.hashicorp.com/terraform/language/resources/terraform-data).

--- a/main.tf
+++ b/main.tf
@@ -20,4 +20,5 @@ provider "aws" {
 module "terrahouse_aws" {
   source = "./modules/terrahouse_aws"
   bucket_name = var.bucket_name
+  content_version = var.content_version
 }

--- a/modules/terrahouse_aws/resource-storage.tf
+++ b/modules/terrahouse_aws/resource-storage.tf
@@ -20,6 +20,10 @@ resource "aws_s3_object" "index_html" {
   source = "${path.root}/public/index.html"
   content_type = "text/html"
   etag = filemd5("${path.root}/public/index.html")
+  lifecycle {
+    replace_triggered_by = [terraform_data.content_version]
+    ignore_changes = [etag]
+  }
 }
 
 resource "aws_s3_object" "error_html" {
@@ -28,6 +32,10 @@ resource "aws_s3_object" "error_html" {
   source = "${path.root}/public/error.html"
   content_type = "text/html"
   etag = filemd5("${path.root}/public/error.html")
+  lifecycle {
+    replace_triggered_by = [terraform_data.content_version]
+    ignore_changes = [etag]
+  }
 }
 
 data "aws_iam_policy_document" "allow_access_from_cloudfront" {
@@ -52,4 +60,8 @@ data "aws_iam_policy_document" "allow_access_from_cloudfront" {
 resource "aws_s3_bucket_policy" "website-bucket-policy" {
   bucket = aws_s3_bucket.website-bucket.id
   policy = data.aws_iam_policy_document.allow_access_from_cloudfront.json
+}
+
+resource "terraform_data" "content_version" {
+  input = var.content_version
 }

--- a/modules/terrahouse_aws/variables.tf
+++ b/modules/terrahouse_aws/variables.tf
@@ -2,3 +2,7 @@ variable bucket_name {
     description = "The name of the s3 bucket"
     type = string
 }
+
+variable content_version {
+    type = number
+}

--- a/variables.tf
+++ b/variables.tf
@@ -2,3 +2,7 @@ variable bucket_name {
     description = "The name of the s3 bucket"
     type = string
 }
+
+variable content_version {
+    type = number
+}


### PR DESCRIPTION
- [x] Only update S3 Objects files when we set a content version, however, this does not invalidate the cache yet.